### PR TITLE
Move two variables to protected

### DIFF
--- a/src/BleSerial.cpp
+++ b/src/BleSerial.cpp
@@ -83,7 +83,7 @@ size_t BleSerial::write(const uint8_t *buffer, size_t bufferSize)
 
 		if (maxTransferSize != oldTransferSize)
 		{
-			ESP_LOGE(TAG, "Max BLE transfer size set to %u", maxTransferSize);
+			log_e("Max BLE transfer size set to %u", maxTransferSize);
 		}
 	}
 

--- a/src/BleSerial.h
+++ b/src/BleSerial.h
@@ -47,6 +47,9 @@ public:
 
 	bool enableLed = false;
 	int ledPin = 13;
+protected:
+	size_t transmitBufferLength;
+	bool bleConnected;
 
 private:
 	BleSerial(BleSerial const &other) = delete;		 // disable copy constructor
@@ -56,12 +59,10 @@ private:
 	size_t numAvailableLines;
 
 	unsigned long long lastFlushTime;
-	size_t transmitBufferLength;
 	uint8_t transmitBuffer[BLE_BUFFER_SIZE];
 
 	int ConnectedDeviceCount;
 	void SetupSerialService();
-	bool bleConnected;
 
 	uint16_t peerMTU;
 	uint16_t maxTransferSize = BLE_BUFFER_SIZE;


### PR DESCRIPTION
Moved two variables to protected so that your lib will compile inside @burnsed [#238 PR](https://github.com/sparkfun/SparkFun_RTK_Firmware/pull/238) on the RTK Firmware. If I'm not mistaken, he modified these lines but missed them in his #1 PR.