### PR TITLE
Change pCharacteristic->getValue return type - for arduino-esp32 v3.0.0

### DIFF
--- a/src/BleSerial.cpp
+++ b/src/BleSerial.cpp
@@ -164,7 +164,7 @@ void BleSerial::onWrite(BLECharacteristic *pCharacteristic)
 {
 	if (pCharacteristic->getUUID().toString() == BLE_RX_UUID)
 	{
-		std::string value = pCharacteristic->getValue();
+		String value = pCharacteristic->getValue().c_str();
 
 		for (int i = 0; i < value.length(); i++)
 			receiveBuffer.add(value[i]);


### PR DESCRIPTION
Hi Avinab (@avinabmalla ),

This Pull Request contains the fix for issue #15 . It allows the code to compile on both arduino-esp32 v2.0 and v3.0, and - I believe - should be compatible with all other platforms too.

Thanks - and best wishes,
Paul (SparkFun)