### PR TITLE
Make bleserial_multiple compatible with Arduino ESP32 v3.x

### DIFF
--- a/examples/BleSerial_Multiple/bleserial_multiple.ino
+++ b/examples/BleSerial_Multiple/bleserial_multiple.ino
@@ -17,6 +17,7 @@
 #include <esp_attr.h>
 #include <esp_task_wdt.h>
 #include <driver/rtc_io.h>
+#include <esp_mac.h>
 
 const int BUFFER_SIZE = 8192;
 const int STACK_SIZE = 8192;


### PR DESCRIPTION
Needed for v3.x of the Arduino ESP32 core.