### PR TITLE
Fix warning caused by tab mistakenly used instead of spaces

### DIFF
--- a/src/BleBatteryService.cpp
+++ b/src/BleBatteryService.cpp
@@ -35,8 +35,8 @@ void BleBatteryService::reportBatteryPercent(uint8_t batPercent) const
     if (!started)
         return;
 
-	batteryCharacteristic->setValue(&batPercent, 1);
-	batteryCharacteristic->notify();
+    batteryCharacteristic->setValue(&batPercent, 1);
+    batteryCharacteristic->notify();
 }
 
 void BleBatteryService::end()


### PR DESCRIPTION
Fixes warning

```
ESP32_BleSerial/src/BleBatteryService.cpp:35:5: In member function 'void BleBatteryService::reportBatteryPercent(uint8_t) const': [-Wmisleading-indentation]
   35 |     if (!started)
      |     ^~
ESP32_BleSerial/src/BleBatteryService.cpp:38:9: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'if'
   38 |         batteryCharacteristic->setValue(&batPercent, 1);
      |         ^~~~~~~~~~~~~~~~~~~~~
```

In other files tabs are used instead of spaces, but this is the only case which creates a warning