### PR TITLE
Fix for Issues #25 and #27

### DIFF
--- a/src/BleBatteryService.cpp
+++ b/src/BleBatteryService.cpp
@@ -44,7 +44,7 @@ void BleBatteryService::reportBatteryPercent(uint8_t batPercent) const
 
 void BleBatteryService::end()
 {
+    batteryService->executeDelete();
     BleSerialServer::getInstance().unregisterBatteryService();
     started = false;
-    batteryService->executeDelete();
 }

--- a/src/BleBufferedSerial.cpp
+++ b/src/BleBufferedSerial.cpp
@@ -62,8 +62,8 @@ void BleBufferedSerial::end()
 	started = false; // This stops the flush task
 	while (flushTaskRunning)
 		vTaskDelay(1); // Wait for the flush task to stop
-	BleSerialServer::getInstance().unregisterSerial();
 	serialService->executeDelete();
+	BleSerialServer::getInstance().unregisterSerial();
 }
 
 bool BleBufferedSerial::connected()

--- a/src/BleBufferedSerial.h
+++ b/src/BleBufferedSerial.h
@@ -80,6 +80,7 @@ private:
 
 	void setupSerialService();
 	bool started = false;
+	bool flushTaskRunning = false;
 
 	int sendByte(uint8_t byte);
 

--- a/src/BleBufferedSerial.h
+++ b/src/BleBufferedSerial.h
@@ -76,7 +76,7 @@ private:
 	ByteRingBuffer<BLE_RX_BUFFER_SIZE> receiveBuffer;
 	size_t numAvailableLines = 0;
 
-	ByteRingBuffer<BLE_MAX_PACKET_SIZE> transmitBuffer;
+	ByteRingBuffer<BLE_MAX_PACKET_SIZE + 1> transmitBuffer;
 
 	void setupSerialService();
 	bool started = false;


### PR DESCRIPTION
Hi Avinab ( @avinabmalla ),

I have been working on a fix for issue #25 . My solution is to: perform a ```vTaskDelete``` in ```flushTaskEntry``` ; and to wait for the task to complete before calling ```unregisterSerial``` and ```executeDelete```.

I am using this fix in the SparkFun RTK Everywhere Firmware and it is working well. I am able to ```end``` and ```begin``` ```BleBufferedSerial``` successfully, without it crashing.

**Edit:** this PR also includes a fix for #27 . It increases the size of ```BleBufferedSerial``` ```transmitBuffer``` by 1.

Best wishes,
Paul (SparkFun)